### PR TITLE
💾 Demo data

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,7 @@ jobs:
     name: ⚗️ Application Tests
     uses: WGBH-MLA/.github/.github/workflows/pytest.yml@main
     with:
-      pytest_args: -n auto
+      pytest_args: -q -n auto
 
   lint:
     name: 👕 Lint

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ __pycache__
 *.sqlite
 
 # Local pdm config
-.pdm.toml
+pdm.toml
+.pdm-python
 
 # PEP 582 local files
 __pypackages__/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ site/
 
 # PyTorch generated file
 *.pth
+
+# Ignore jupyter notebook session
+session.ipynb

--- a/chowda/config.py
+++ b/chowda/config.py
@@ -1,6 +1,8 @@
 from os import environ
 
-PRODUCTION = bool(environ.get('PRODUCTION', False))
+ENVIRONMENT = environ.get('ENVIRONMENT', 'dev')
 
-DATABASE_FILE = environ.get('DB_FILE', 'chowda.sqlite')
-ENGINE_URI = environ.get('DB_URL', 'sqlite:///' + DATABASE_FILE)
+DB_FILE = environ.get('DB_FILE', 'chowda.sqlite')
+DB_URL = environ.get('DB_URL', 'sqlite:///' + DB_FILE)
+
+ECHO = True

--- a/chowda/db.py
+++ b/chowda/db.py
@@ -1,17 +1,20 @@
 from sqlalchemy import create_engine
-from .config import ENGINE_URI, PRODUCTION
+from .config import DB_URL, ENVIRONMENT, ECHO
 
-connect_args = {}
+connect_args = {'check_same_thread': False}
 
-if not PRODUCTION:
-    connect_args['check_same_thread'] = False
 
-engine = create_engine(ENGINE_URI, connect_args=connect_args, echo=not PRODUCTION)
+if ENVIRONMENT == 'production':
+    ECHO = False
+
+if ENVIRONMENT == 'test':
+    DB_URL = 'sqlite:///:memory:'
+
+
+engine = create_engine(DB_URL, connect_args=connect_args, echo=ECHO)
 
 
 def create_async_engine():
     from sqlmodel.ext.asyncio.session import AsyncEngine
 
-    return AsyncEngine(
-        create_engine(ENGINE_URI, connect_args=connect_args, echo=not PRODUCTION)
-    )
+    return AsyncEngine(create_engine(DB_URL, connect_args=connect_args, echo=ECHO))

--- a/chowda/models.py
+++ b/chowda/models.py
@@ -3,12 +3,9 @@
 SQLModels for DB and validation
 """
 
-from datetime import datetime
 from typing import Any, Dict, List, Optional
 from pydantic import AnyHttpUrl, EmailStr, stricturl
-from pydantic import Field as PydField
-from pydantic.color import Color
-from sqlalchemy import JSON, Column, DateTime, Enum, String, Text
+from sqlalchemy import JSON, Column
 
 from sqlmodel import Field, Relationship, SQLModel
 
@@ -83,9 +80,12 @@ class Batch(SQLModel, table=True):
     id: Optional[int] = Field(primary_key=True)
     name: str
     description: str
+    pipeline_id: Optional[int] = Field(default=None, foreign_key='pipelines.id')
+    pipeline: Optional['Pipeline'] = Relationship(back_populates='batches')
     media_files: List[MediaFile] = Relationship(
         back_populates='batches', link_model=MediaFileBatchLink
     )
+    clams_events: List['ClamsEvent'] = Relationship(back_populates='batch')
 
 
 class ClamsAppPipelineLink(SQLModel, table=True):
@@ -117,7 +117,7 @@ class Pipeline(SQLModel, table=True):
     clams_apps: List[ClamsApp] = Relationship(
         back_populates='pipelines', link_model=ClamsAppPipelineLink
     )
-    clams_events: List['ClamsEvent'] = Relationship(back_populates='pipeline')
+    batches: List[Batch] = Relationship(back_populates='pipeline')
 
 
 class ClamsEvent(SQLModel, table=True):
@@ -125,8 +125,8 @@ class ClamsEvent(SQLModel, table=True):
     id: Optional[int] = Field(primary_key=True)
     status: str
     response_json: Dict[str, Any] = Field(sa_column=Column(JSON))
-    pipeline_id: Optional[int] = Field(default=None, foreign_key='pipelines.id')
-    pipeline: Optional[Pipeline] = Relationship(back_populates='clams_events')
+    batch_id: Optional[int] = Field(default=None, foreign_key='batches.id')
+    batch: Optional[Batch] = Relationship(back_populates='clams_events')
     clams_app_id: Optional[int] = Field(default=None, foreign_key='clams_apps.id')
     clams_app: Optional[ClamsApp] = Relationship(back_populates='clams_events')
     media_file_id: Optional[int] = Field(default=None, foreign_key='media_files.id')

--- a/pdm.lock
+++ b/pdm.lock
@@ -12,12 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "attrs"
-version = "22.2.0"
-requires_python = ">=3.6"
-summary = "Classes Without Boilerplate"
-
-[[package]]
 name = "babel"
 version = "2.12.1"
 requires_python = ">=3.7"
@@ -158,17 +152,6 @@ summary = "FastAPI framework, high performance, easy to learn, fast to code, rea
 dependencies = [
     "pydantic!=1.7,!=1.7.1,!=1.7.2,!=1.7.3,!=1.8,!=1.8.1,<2.0.0,>=1.6.2",
     "starlette<0.27.0,>=0.26.1",
-]
-
-[[package]]
-name = "flake8"
-version = "6.0.0"
-requires_python = ">=3.8.1"
-summary = "the modular source code checker: pep8 pyflakes and co"
-dependencies = [
-    "mccabe<0.8.0,>=0.7.0",
-    "pycodestyle<2.11.0,>=2.10.0",
-    "pyflakes<3.1.0,>=3.0.0",
 ]
 
 [[package]]
@@ -394,12 +377,6 @@ requires_python = ">=3.7"
 summary = "Safely add untrusted strings to HTML/XML markup."
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-requires_python = ">=3.6"
-summary = "McCabe checker, plugin for flake8"
-
-[[package]]
 name = "mergedeep"
 version = "1.3.4"
 requires_python = ">=3.6"
@@ -464,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.1.4"
+version = "9.1.6"
 requires_python = ">=3.7"
 summary = "Documentation that simply works"
 dependencies = [
@@ -487,7 +464,7 @@ summary = "Extension pack for Python Markdown and MkDocs Material."
 
 [[package]]
 name = "mkdocstrings"
-version = "0.20.0"
+version = "0.21.2"
 requires_python = ">=3.7"
 summary = "Automatic documentation from sources, for MkDocs."
 dependencies = [
@@ -497,6 +474,7 @@ dependencies = [
     "mkdocs-autorefs>=0.3.1",
     "mkdocs>=1.2",
     "pymdown-extensions>=6.3",
+    "typing-extensions>=4.1; python_version < \"3.10\"",
 ]
 
 [[package]]
@@ -511,13 +489,13 @@ dependencies = [
 
 [[package]]
 name = "mkdocstrings"
-version = "0.20.0"
+version = "0.21.2"
 extras = ["python"]
 requires_python = ">=3.7"
 summary = "Automatic documentation from sources, for MkDocs."
 dependencies = [
     "mkdocstrings-python>=0.5.2",
-    "mkdocstrings==0.20.0",
+    "mkdocstrings==0.21.2",
 ]
 
 [[package]]
@@ -563,15 +541,9 @@ summary = "Cross-platform lib for process and system monitoring in Python."
 
 [[package]]
 name = "psycopg2"
-version = "2.9.5"
+version = "2.9.6"
 requires_python = ">=3.6"
 summary = "psycopg2 - Python-PostgreSQL Database Adapter"
-
-[[package]]
-name = "pycodestyle"
-version = "2.10.0"
-requires_python = ">=3.6"
-summary = "Python style guide checker"
 
 [[package]]
 name = "pycparser"
@@ -590,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-factories"
-version = "1.17.2"
+version = "1.17.3"
 requires_python = ">=3.8,<4.0"
 summary = "Mock data generation for pydantic based models and python dataclasses"
 dependencies = [
@@ -611,12 +583,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pyflakes"
-version = "3.0.1"
-requires_python = ">=3.6"
-summary = "passive checker of Python programs"
-
-[[package]]
 name = "pygments"
 version = "2.14.0"
 requires_python = ">=3.6"
@@ -634,11 +600,10 @@ dependencies = [
 
 [[package]]
 name = "pytest"
-version = "7.2.2"
+version = "7.3.0"
 requires_python = ">=3.7"
 summary = "pytest: simple powerful testing with Python"
 dependencies = [
-    "attrs>=19.2.0",
     "colorama; sys_platform == \"win32\"",
     "exceptiongroup>=1.0.0rc8; python_version < \"3.11\"",
     "iniconfig",
@@ -659,12 +624,12 @@ dependencies = [
 
 [[package]]
 name = "pytest-sugar"
-version = "0.9.6"
+version = "0.9.7"
 summary = "pytest-sugar is a plugin for pytest that changes the default look and feel of pytest (e.g. progressbar, show tests that fail instantly)."
 dependencies = [
-    "packaging>=14.1",
-    "pytest>=2.9",
-    "termcolor>=1.1.0",
+    "packaging>=21.3",
+    "pytest>=6.2.0",
+    "termcolor>=2.1.0",
 ]
 
 [[package]]
@@ -771,6 +736,12 @@ version = "0.0.4"
 summary = "Collection of roundrobin utilities"
 
 [[package]]
+name = "ruff"
+version = "0.0.261"
+requires_python = ">=3.7"
+summary = "An extremely fast Python linter, written in Rust."
+
+[[package]]
 name = "setuptools"
 version = "67.6.1"
 requires_python = ">=3.7"
@@ -835,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "starlette-admin"
-version = "0.7.0"
+version = "0.8.0"
 requires_python = ">=3.7"
 summary = "Fast, beautiful and extensible administrative interface framework for Starlette/FastApi applications"
 dependencies = [
@@ -960,17 +931,14 @@ dependencies = [
 ]
 
 [metadata]
-lock_version = "4.1"
-content_hash = "sha256:74fd6c7892917689132fa6821c6cba543d7febc92f02492356261db0a62d394b"
+lock_version = "4.2"
+groups = ["default", "dev", "docs", "locust", "production", "test"]
+content_hash = "sha256:8376a2b068714b4c021576a58180d094323aab94c631f0d350ba811f9f54606f"
 
 [metadata.files]
 "anyio 3.6.2" = [
     {url = "https://files.pythonhosted.org/packages/77/2b/b4c0b7a3f3d61adb1a1e0b78f90a94e2b6162a043880704b7437ef297cad/anyio-3.6.2-py3-none-any.whl", hash = "sha256:fbbe32bd270d2a2ef3ed1c5d45041250284e31fc0a4df4a5a6071842051a51e3"},
     {url = "https://files.pythonhosted.org/packages/8b/94/6928d4345f2bc1beecbff03325cad43d320717f51ab74ab5a571324f4f5a/anyio-3.6.2.tar.gz", hash = "sha256:25ea0d673ae30af41a0c442f81cf3b38c7e79fdc7b60335a4c14e05eb0947421"},
-]
-"attrs 22.2.0" = [
-    {url = "https://files.pythonhosted.org/packages/21/31/3f468da74c7de4fcf9b25591e682856389b3400b4b62f201e65f15ea3e07/attrs-22.2.0.tar.gz", hash = "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"},
-    {url = "https://files.pythonhosted.org/packages/fb/6e/6f83bf616d2becdf333a1640f1d463fef3150e2e926b7010cb0f81c95e88/attrs-22.2.0-py3-none-any.whl", hash = "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836"},
 ]
 "babel 2.12.1" = [
     {url = "https://files.pythonhosted.org/packages/ba/42/54426ba5d7aeebde9f4aaba9884596eb2fe02b413ad77d62ef0b0422e205/Babel-2.12.1.tar.gz", hash = "sha256:cc2d99999cd01d44420ae725a21c9e3711b3aadc7976d6147f622d8581963455"},
@@ -1326,10 +1294,6 @@ content_hash = "sha256:74fd6c7892917689132fa6821c6cba543d7febc92f02492356261db0a
 "fastapi 0.95.0" = [
     {url = "https://files.pythonhosted.org/packages/38/a0/122f89a38bb42260bc65ec37ebce40457ea0731a0949af43a4c7a6dbadfd/fastapi-0.95.0.tar.gz", hash = "sha256:99d4fdb10e9dd9a24027ac1d0bd4b56702652056ca17a6c8721eec4ad2f14e18"},
     {url = "https://files.pythonhosted.org/packages/3f/91/5412a4c845d1b88cfded182b0e5553e3498a38e5a65a8e9b02e3aaf47dd5/fastapi-0.95.0-py3-none-any.whl", hash = "sha256:daf73bbe844180200be7966f68e8ec9fd8be57079dff1bacb366db32729e6eb5"},
-]
-"flake8 6.0.0" = [
-    {url = "https://files.pythonhosted.org/packages/66/53/3ad4a3b74d609b3b9008a10075c40e7c8909eae60af53623c3888f7a529a/flake8-6.0.0.tar.gz", hash = "sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181"},
-    {url = "https://files.pythonhosted.org/packages/d9/6a/bb0122ebe280476c924470779d2595f1403878cafe3c8a343ac56a5a9c0e/flake8-6.0.0-py2.py3-none-any.whl", hash = "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7"},
 ]
 "flask 2.2.3" = [
     {url = "https://files.pythonhosted.org/packages/95/9c/a3542594ce4973786236a1b7b702b8ca81dbf40ea270f0f96284f0c27348/Flask-2.2.3-py3-none-any.whl", hash = "sha256:c0bec9477df1cb867e5a67c9e1ab758de9cb4a3e52dd70681f59fa40a62b3f2d"},
@@ -1709,10 +1673,6 @@ content_hash = "sha256:74fd6c7892917689132fa6821c6cba543d7febc92f02492356261db0a
     {url = "https://files.pythonhosted.org/packages/ea/60/2400ba59cf2465fa136487ee7299f52121a9d04b2cf8539ad43ad10e70e8/MarkupSafe-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:e55e40ff0cc8cc5c07996915ad367fa47da6b3fc091fdadca7f5403239c5fec3"},
     {url = "https://files.pythonhosted.org/packages/f9/aa/ebcd114deab08f892b1d70badda4436dbad1747f9e5b72cffb3de4c7129d/MarkupSafe-2.1.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7313ce6a199651c4ed9d7e4cfb4aa56fe923b1adf9af3b420ee14e6d9a73df65"},
 ]
-"mccabe 0.7.0" = [
-    {url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
-]
 "mergedeep 1.3.4" = [
     {url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307"},
     {url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8"},
@@ -1729,17 +1689,17 @@ content_hash = "sha256:74fd6c7892917689132fa6821c6cba543d7febc92f02492356261db0a
     {url = "https://files.pythonhosted.org/packages/86/5f/5cc21fcdaa14f7e01d7f9c3e2116bda975917e64eb8bf19d110eb74f6bcb/mkdocs-git-revision-date-localized-plugin-1.2.0.tar.gz", hash = "sha256:7752edd7c4dcaa9383e9a5b6a4f729831a62d604b0c43b319331127720c6a2bf"},
     {url = "https://files.pythonhosted.org/packages/c5/9f/dad0e4935fe18ea1163bf1bef56d41fe6d6ebc536ddb48793555f07fcc53/mkdocs_git_revision_date_localized_plugin-1.2.0-py3-none-any.whl", hash = "sha256:540b9c930d8d48630c090b72ac2c3900ac2ed0799b23738a33b88e31f5198fe7"},
 ]
-"mkdocs-material 9.1.4" = [
-    {url = "https://files.pythonhosted.org/packages/0a/63/0cef97c243c05ef9a738bc524297c3edc09d1b806db97cfdddbb2dd59845/mkdocs_material-9.1.4.tar.gz", hash = "sha256:c3a8943e9e4a7d2624291da365bbccf0b9f88688aa6947a46260d8c165cd4389"},
-    {url = "https://files.pythonhosted.org/packages/d8/c7/8984af2e3d2046930c3441d58b8a30e854ec400316a427fe12292b976d90/mkdocs_material-9.1.4-py3-none-any.whl", hash = "sha256:4c92dcf9365068259bef3eed8e0dd5410056b6f7187bdea2d52848c0f94cd94c"},
+"mkdocs-material 9.1.6" = [
+    {url = "https://files.pythonhosted.org/packages/24/04/93f4cb044bfb667db1f214f16eab45030815ee397395d37d3e1c3d7cff4d/mkdocs_material-9.1.6.tar.gz", hash = "sha256:2e555152f9771646bfa62dc78a86052876183eff69ce30db03a33e85702b21fc"},
+    {url = "https://files.pythonhosted.org/packages/bd/99/2800234c54a63a5e892bf336baaf3ae8184b2e0c9080c3779fa74bcde976/mkdocs_material-9.1.6-py3-none-any.whl", hash = "sha256:f2eb1d40db89da9922944833c1387207408f8937e1c2b46ab86e0c8f170b71e0"},
 ]
 "mkdocs-material-extensions 1.1.1" = [
     {url = "https://files.pythonhosted.org/packages/cd/3f/e5e3c9bfbb42e4cb661f71bcec787ae6bdf4a161b8c4bb68fd7d991c436c/mkdocs_material_extensions-1.1.1.tar.gz", hash = "sha256:9c003da71e2cc2493d910237448c672e00cefc800d3d6ae93d2fc69979e3bd93"},
     {url = "https://files.pythonhosted.org/packages/fd/c9/35af8ceabace3e33d1fb64b1749c6f4dac6129faa32f8a4229791f89f56a/mkdocs_material_extensions-1.1.1-py3-none-any.whl", hash = "sha256:e41d9f38e4798b6617ad98ca8f7f1157b1e4385ac1459ca1e4ea219b556df945"},
 ]
-"mkdocstrings 0.20.0" = [
-    {url = "https://files.pythonhosted.org/packages/22/08/dd06d533879ba4694bb31b0f4b8d8ec3b50ed51d8717083bdf6a8a0bd065/mkdocstrings-0.20.0-py3-none-any.whl", hash = "sha256:f17fc2c4f760ec302b069075ef9e31045aa6372ca91d2f35ded3adba8e25a472"},
-    {url = "https://files.pythonhosted.org/packages/70/03/6efc9dbff20304a4dc826eb8411d462afb44c8b1605b7d707c70a5ba8169/mkdocstrings-0.20.0.tar.gz", hash = "sha256:c757f4f646d4f939491d6bc9256bfe33e36c5f8026392f49eaa351d241c838e5"},
+"mkdocstrings 0.21.2" = [
+    {url = "https://files.pythonhosted.org/packages/04/ca/7630aa270d8af95eadccc13836e5471a0d639d41555ec894e78a83d1a4cd/mkdocstrings-0.21.2-py3-none-any.whl", hash = "sha256:949ef8da92df9d692ca07be50616459a6b536083a25520fd54b00e8814ce019b"},
+    {url = "https://files.pythonhosted.org/packages/d2/a1/d08d776e8fa2508b299fad8165374317dc742a58880398ed2f9a7ecddefc/mkdocstrings-0.21.2.tar.gz", hash = "sha256:304e56a2e90595708a38a13a278e538a67ad82052dd5c8b71f77a604a4f3d911"},
 ]
 "mkdocstrings-python 0.8.3" = [
     {url = "https://files.pythonhosted.org/packages/2c/30/47c1db07d5a6ecbf9a8ea251e1cfb91ec5f8bc4ab1ead417dcc1932ab616/mkdocstrings-python-0.8.3.tar.gz", hash = "sha256:9ae473f6dc599339b09eee17e4d2b05d6ac0ec29860f3fc9b7512d940fc61adf"},
@@ -1846,24 +1806,20 @@ content_hash = "sha256:74fd6c7892917689132fa6821c6cba543d7febc92f02492356261db0a
     {url = "https://files.pythonhosted.org/packages/a5/73/35cea01aad1baf901c915dc95ea33a2f271c8ff8cf2f1c73b7f591f1bdf1/psutil-5.9.4-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:54d5b184728298f2ca8567bf83c422b706200bcbbfafdc06718264f9393cfeb7"},
     {url = "https://files.pythonhosted.org/packages/ec/be/b8df2071eda861e65a1b2cec35770bb1f4523737e84a10aa41c53e39e9bc/psutil-5.9.4-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:6b92c532979bafc2df23ddc785ed116fced1f492ad90a6830cf24f4d1ea27d24"},
 ]
-"psycopg2 2.9.5" = [
-    {url = "https://files.pythonhosted.org/packages/04/51/00ed720de223485a56c28b404747b96806679e720f4c97a75bdd556a01f4/psycopg2-2.9.5-cp310-cp310-win32.whl", hash = "sha256:d3ef67e630b0de0779c42912fe2cbae3805ebaba30cda27fea2a3de650a9414f"},
-    {url = "https://files.pythonhosted.org/packages/10/db/a34baee6275fcc371ecdb30040042ed2a548f18c29339ea9ca2406a35cba/psycopg2-2.9.5-cp39-cp39-win_amd64.whl", hash = "sha256:190d51e8c1b25a47484e52a79638a8182451d6f6dff99f26ad9bd81e5359a0fa"},
-    {url = "https://files.pythonhosted.org/packages/23/b2/679ba212dd7fc5f726913053756b23344d5520b4fa49c2a93af31d0f4508/psycopg2-2.9.5-cp311-cp311-win_amd64.whl", hash = "sha256:920bf418000dd17669d2904472efeab2b20546efd0548139618f8fa305d1d7ad"},
-    {url = "https://files.pythonhosted.org/packages/7e/48/98e0d097fc23d772f525f54b3c62becadf839f2f84ee6600e283dde5dfe7/psycopg2-2.9.5-cp38-cp38-win_amd64.whl", hash = "sha256:1a5c7d7d577e0eabfcf15eb87d1e19314c8c4f0e722a301f98e0e3a65e238b4e"},
-    {url = "https://files.pythonhosted.org/packages/83/5c/fe9e713ef1d352fbaae0ecdae05a9882ad9466f46100a8aa2962d858e62a/psycopg2-2.9.5-cp37-cp37m-win32.whl", hash = "sha256:922cc5f0b98a5f2b1ff481f5551b95cd04580fd6f0c72d9b22e6c0145a4840e0"},
-    {url = "https://files.pythonhosted.org/packages/89/d6/cd8c46417e0f7a16b4b0fc321f4ab676a59250d08fce5b64921897fb07cc/psycopg2-2.9.5.tar.gz", hash = "sha256:a5246d2e683a972e2187a8714b5c2cf8156c064629f9a9b1a873c1730d9e245a"},
-    {url = "https://files.pythonhosted.org/packages/9f/1f/df4c9ab12634dc89c71c2184b2524adccd804af2bacc8968a7c831642338/psycopg2-2.9.5-cp311-cp311-win32.whl", hash = "sha256:093e3894d2d3c592ab0945d9eba9d139c139664dcf83a1c440b8a7aa9bb21955"},
-    {url = "https://files.pythonhosted.org/packages/ae/f4/b01b7d33f5456e26b3f41fd13c93aa1c58528e3306d801133ec81dfcd81a/psycopg2-2.9.5-cp36-cp36m-win32.whl", hash = "sha256:b9ac1b0d8ecc49e05e4e182694f418d27f3aedcfca854ebd6c05bb1cffa10d6d"},
-    {url = "https://files.pythonhosted.org/packages/af/4f/3abf262dc49cb70c2fbb6d38a9a8956a0c79ba2d102e457958bc4f21660f/psycopg2-2.9.5-cp310-cp310-win_amd64.whl", hash = "sha256:4cb9936316d88bfab614666eb9e32995e794ed0f8f6b3b718666c22819c1d7ee"},
-    {url = "https://files.pythonhosted.org/packages/b4/f4/c45a12b538c1ef9e36681d2ddec7d397961bdd9ba53de01bdce32acdb348/psycopg2-2.9.5-cp38-cp38-win32.whl", hash = "sha256:f5b6320dbc3cf6cfb9f25308286f9f7ab464e65cfb105b64cc9c52831748ced2"},
-    {url = "https://files.pythonhosted.org/packages/c2/e7/5cf79928c362cd661765a18d7015b2e0b48f01d9a41dad42d7d945c11a93/psycopg2-2.9.5-cp36-cp36m-win_amd64.whl", hash = "sha256:fc04dd5189b90d825509caa510f20d1d504761e78b8dfb95a0ede180f71d50e5"},
-    {url = "https://files.pythonhosted.org/packages/c8/80/9c4a7f453fbef2acc65a66f79def6b048787f5ff82005682a98252311e68/psycopg2-2.9.5-cp39-cp39-win32.whl", hash = "sha256:322fd5fca0b1113677089d4ebd5222c964b1760e361f151cbb2706c4912112c5"},
-    {url = "https://files.pythonhosted.org/packages/d1/c5/ff268400b5fae84d8070e7b7a8c9425c635a24a68eee587f86adcf11bb13/psycopg2-2.9.5-cp37-cp37m-win_amd64.whl", hash = "sha256:1e5a38aa85bd660c53947bd28aeaafb6a97d70423606f1ccb044a03a1203fe4a"},
-]
-"pycodestyle 2.10.0" = [
-    {url = "https://files.pythonhosted.org/packages/06/6b/5ca0d12ef7dcf7d20dfa35287d02297f3e0f9e515da5183654c03a9636ce/pycodestyle-2.10.0.tar.gz", hash = "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053"},
-    {url = "https://files.pythonhosted.org/packages/a2/54/001fdc0d69e8d0bb86c3423a6fa6dfada8cc26317c2635ab543e9ac411bd/pycodestyle-2.10.0-py2.py3-none-any.whl", hash = "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610"},
+"psycopg2 2.9.6" = [
+    {url = "https://files.pythonhosted.org/packages/2f/e0/f0db22e36faf2b62557ed11e942cc47f3b96d52b686fa838a3ca6b3c90b3/psycopg2-2.9.6-cp38-cp38-win32.whl", hash = "sha256:2362ee4d07ac85ff0ad93e22c693d0f37ff63e28f0615a16b6635a645f4b9214"},
+    {url = "https://files.pythonhosted.org/packages/49/8e/52252e78c8fd2cc91dae13d2686b103237900fd05f80adc1efc366b40f65/psycopg2-2.9.6-cp39-cp39-win_amd64.whl", hash = "sha256:ded2faa2e6dfb430af7713d87ab4abbfc764d8d7fb73eafe96a24155f906ebf5"},
+    {url = "https://files.pythonhosted.org/packages/4b/6a/450b97eb81f64f4788a6c5c4282ef2f73b023cc1ceab906ca63cab864440/psycopg2-2.9.6-cp311-cp311-win32.whl", hash = "sha256:53f4ad0a3988f983e9b49a5d9765d663bbe84f508ed655affdb810af9d0972ad"},
+    {url = "https://files.pythonhosted.org/packages/4b/8e/69c0ea73e96afc1efb9f459050a14391fae20db81ff1815bf27c8ddc3160/psycopg2-2.9.6-cp38-cp38-win_amd64.whl", hash = "sha256:d24ead3716a7d093b90b27b3d73459fe8cd90fd7065cf43b3c40966221d8c394"},
+    {url = "https://files.pythonhosted.org/packages/9b/e1/04d7d48986b123775840fb64bc07642fe186079564744ed9955162891b24/psycopg2-2.9.6-cp310-cp310-win32.whl", hash = "sha256:f7a7a5ee78ba7dc74265ba69e010ae89dae635eea0e97b055fb641a01a31d2b1"},
+    {url = "https://files.pythonhosted.org/packages/ad/8d/88ab18931ee8d7434163671dbc6bbfd8c07ff8777fe6d156fabcb3672927/psycopg2-2.9.6-cp37-cp37m-win32.whl", hash = "sha256:869776630c04f335d4124f120b7fb377fe44b0a7645ab3c34b4ba42516951889"},
+    {url = "https://files.pythonhosted.org/packages/af/c4/5726cddb53fe52f0e839eb3da04322364f14493217ebd5818cc5e4c948a5/psycopg2-2.9.6.tar.gz", hash = "sha256:f15158418fd826831b28585e2ab48ed8df2d0d98f502a2b4fe619e7d5ca29011"},
+    {url = "https://files.pythonhosted.org/packages/c2/47/d142314e126c0ea7c8f4c0043cad069e359ce04975fd7d296c4af7f5a5c4/psycopg2-2.9.6-cp36-cp36m-win32.whl", hash = "sha256:11aca705ec888e4f4cea97289a0bf0f22a067a32614f6ef64fcf7b8bfbc53744"},
+    {url = "https://files.pythonhosted.org/packages/c9/37/f49a95fb00ca9f4678475284e60cb341aea84201ac45faa9f32ad88c02e8/psycopg2-2.9.6-cp311-cp311-win_amd64.whl", hash = "sha256:b81fcb9ecfc584f661b71c889edeae70bae30d3ef74fa0ca388ecda50b1222b7"},
+    {url = "https://files.pythonhosted.org/packages/ca/4a/b2f2cc9a3384b438961f9953fd82a20514c60a87f378f4a475f1b9de184b/psycopg2-2.9.6-cp310-cp310-win_amd64.whl", hash = "sha256:f75001a1cbbe523e00b0ef896a5a1ada2da93ccd752b7636db5a99bc57c44494"},
+    {url = "https://files.pythonhosted.org/packages/e1/56/6558cc5b4380dc2ef0ea6c96eeb6fcb26111081ec07f0dade2c3b9bc1f06/psycopg2-2.9.6-cp36-cp36m-win_amd64.whl", hash = "sha256:36c941a767341d11549c0fbdbb2bf5be2eda4caf87f65dfcd7d146828bd27f39"},
+    {url = "https://files.pythonhosted.org/packages/e2/38/4a2cc3f697f40f09617697a795c73697eec464009f4c5e47cf4050f45b63/psycopg2-2.9.6-cp37-cp37m-win_amd64.whl", hash = "sha256:a8ad4a47f42aa6aec8d061fdae21eaed8d864d4bb0f0cade5ad32ca16fcd6258"},
+    {url = "https://files.pythonhosted.org/packages/e3/76/08d3297720f2d0636a934aa30bf3343e6c4b869c12ba6294b8c1739af76b/psycopg2-2.9.6-cp39-cp39-win32.whl", hash = "sha256:1861a53a6a0fd248e42ea37c957d36950da00266378746588eab4f4b5649e95f"},
 ]
 "pycparser 2.21" = [
     {url = "https://files.pythonhosted.org/packages/5e/0b/95d387f5f4433cb0f53ff7ad859bd2c6051051cebbb564f139a999ab46de/pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
@@ -1907,13 +1863,9 @@ content_hash = "sha256:74fd6c7892917689132fa6821c6cba543d7febc92f02492356261db0a
     {url = "https://files.pythonhosted.org/packages/fa/c2/3df79cd00e65678fce12e59e8c95378a992a93d7b9f9510d4f1f65df1936/pydantic-1.10.7-cp311-cp311-win_amd64.whl", hash = "sha256:b4a849d10f211389502059c33332e91327bc154acc1845f375a99eca3afa802d"},
     {url = "https://files.pythonhosted.org/packages/fd/66/3da2e7c0306251435bd61ae9da52db8a00672fdf2b2db1e3efe1692f41dd/pydantic-1.10.7-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:950ce33857841f9a337ce07ddf46bc84e1c4946d2a3bba18f8280297157a3fd1"},
 ]
-"pydantic-factories 1.17.2" = [
-    {url = "https://files.pythonhosted.org/packages/60/97/9f1ae52b1eabb1e2e72fbc69ed48c7380a373b5ea8b7f02a20d932b84d97/pydantic_factories-1.17.2.tar.gz", hash = "sha256:a1ea1d3a595235a65f954d6e182ec4bfe94645f2c4d986fd43ae19a62ffb90b0"},
-    {url = "https://files.pythonhosted.org/packages/c5/45/0e76b74a13783032e77066f1f6b7f692020f8d44cc5399518ba3881bda32/pydantic_factories-1.17.2-py3-none-any.whl", hash = "sha256:e1378700a9e963b368b602e46e8ccc3331027f10233e617eb47b3a3dd052ee25"},
-]
-"pyflakes 3.0.1" = [
-    {url = "https://files.pythonhosted.org/packages/af/4c/b1c7008aa7788b3e26c06c60aa18da7d3aa1f00e344aa3f18ac92768854b/pyflakes-3.0.1-py2.py3-none-any.whl", hash = "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf"},
-    {url = "https://files.pythonhosted.org/packages/f2/51/506ddcfab10d708e8460554cc1cf37c727a6a2cccbad8dfe57766cfce33c/pyflakes-3.0.1.tar.gz", hash = "sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd"},
+"pydantic-factories 1.17.3" = [
+    {url = "https://files.pythonhosted.org/packages/31/c1/73e688b29bee1d68604b45e8ce3ee410b4bd09ded23546e18263c1855c74/pydantic_factories-1.17.3.tar.gz", hash = "sha256:de36e0db7108af5f4328308da9a4049311c4d5e0814553d2f39078b08b05e48d"},
+    {url = "https://files.pythonhosted.org/packages/40/49/81bbfccaf7174e7a94be1fa95d9ed46da6663372b2a7cd597c1c6fdfcabe/pydantic_factories-1.17.3-py3-none-any.whl", hash = "sha256:5a1522a31d27e1af414719c510a4a934365292f3ea6fdc843ed65d0564242636"},
 ]
 "pygments 2.14.0" = [
     {url = "https://files.pythonhosted.org/packages/0b/42/d9d95cc461f098f204cd20c85642ae40fbff81f74c300341b8d0e0df14e0/Pygments-2.14.0-py3-none-any.whl", hash = "sha256:fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717"},
@@ -1923,17 +1875,17 @@ content_hash = "sha256:74fd6c7892917689132fa6821c6cba543d7febc92f02492356261db0a
     {url = "https://files.pythonhosted.org/packages/34/30/a16f0671c64c996726c48811b0d2c6c97f8d12926c9ad1c34e21a3d7155b/pymdown_extensions-9.10-py3-none-any.whl", hash = "sha256:31eaa76ce6f96aabfcea98787c2fff2c5c0611b20a53a94213970cfbf05f02b8"},
     {url = "https://files.pythonhosted.org/packages/3e/e6/980687f70088d8b0670dc9e5734fa461967824c6d32ccb238eb22c388254/pymdown_extensions-9.10.tar.gz", hash = "sha256:562c38eee4ce3f101ce631b804bfc2177a8a76c7e4dc908871fb6741a90257a7"},
 ]
-"pytest 7.2.2" = [
-    {url = "https://files.pythonhosted.org/packages/b2/68/5321b5793bd506961bd40bdbdd0674e7de4fb873ee7cab33dd27283ad513/pytest-7.2.2-py3-none-any.whl", hash = "sha256:130328f552dcfac0b1cec75c12e3f005619dc5f874f0a06e8ff7263f0ee6225e"},
-    {url = "https://files.pythonhosted.org/packages/b9/29/311895d9cd3f003dd58e8fdea36dd895ba2da5c0c90601836f7de79f76fe/pytest-7.2.2.tar.gz", hash = "sha256:c99ab0c73aceb050f68929bc93af19ab6db0558791c6a0715723abe9d0ade9d4"},
+"pytest 7.3.0" = [
+    {url = "https://files.pythonhosted.org/packages/2b/a6/22c1138c2a7b60c9eb9ddeac017d82a58dfd9661651c721e7466af648764/pytest-7.3.0.tar.gz", hash = "sha256:58ecc27ebf0ea643ebfdf7fb1249335da761a00c9f955bcd922349bcb68ee57d"},
+    {url = "https://files.pythonhosted.org/packages/83/b8/345f25e35406da60b5cb0cb9de9f92a96f44eae618dc2cc4a00a2bf416f9/pytest-7.3.0-py3-none-any.whl", hash = "sha256:933051fa1bfbd38a21e73c3960cebdad4cf59483ddba7696c48509727e17f201"},
 ]
 "pytest-cov 4.0.0" = [
     {url = "https://files.pythonhosted.org/packages/ea/70/da97fd5f6270c7d2ce07559a19e5bf36a76f0af21500256f005a69d9beba/pytest-cov-4.0.0.tar.gz", hash = "sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470"},
     {url = "https://files.pythonhosted.org/packages/fe/1f/9ec0ddd33bd2b37d6ec50bb39155bca4fe7085fa78b3b434c05459a860e3/pytest_cov-4.0.0-py3-none-any.whl", hash = "sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b"},
 ]
-"pytest-sugar 0.9.6" = [
-    {url = "https://files.pythonhosted.org/packages/11/71/2bddd9f3f7fb267b31d7c6236dfb021d28b843f810b3fff57cf9194ef34b/pytest-sugar-0.9.6.tar.gz", hash = "sha256:c4793495f3c32e114f0f5416290946c316eb96ad5a3684dcdadda9267e59b2b8"},
-    {url = "https://files.pythonhosted.org/packages/3e/05/4375ccf896e5dccce262a37a432ae0eea0fdaa8d6812020271ce9087263b/pytest_sugar-0.9.6-py2.py3-none-any.whl", hash = "sha256:30e5225ed2b3cc988a8a672f8bda0fc37bcd92d62e9273937f061112b3f2186d"},
+"pytest-sugar 0.9.7" = [
+    {url = "https://files.pythonhosted.org/packages/57/18/fe569040c5796879288544b1cc98888fce1754138d54e8287ed21614491e/pytest-sugar-0.9.7.tar.gz", hash = "sha256:f1e74c1abfa55f7241cf7088032b6e378566f16b938f3f08905e2cf4494edd46"},
+    {url = "https://files.pythonhosted.org/packages/c7/b2/8f5d346c86e690c58da3b21b7c14d656b4100606abed8e91a98e8b50f3bf/pytest_sugar-0.9.7-py2.py3-none-any.whl", hash = "sha256:8cb5a4e5f8bbcd834622b0235db9e50432f4cbd71fef55b467fe44e43701e062"},
 ]
 "pytest-xdist 3.2.1" = [
     {url = "https://files.pythonhosted.org/packages/41/69/319ff6c2bda31b0ab0710d2bb406d53f7d9c13a1c572696479a16322d9dc/pytest_xdist-3.2.1-py3-none-any.whl", hash = "sha256:37290d161638a20b672401deef1cba812d110ac27e35d213f091d15b8beb40c9"},
@@ -2169,6 +2121,25 @@ content_hash = "sha256:74fd6c7892917689132fa6821c6cba543d7febc92f02492356261db0a
 "roundrobin 0.0.4" = [
     {url = "https://files.pythonhosted.org/packages/38/97/6508c09e3af7eaee96e7b66a7dc7bbdbe8e6b85b8d2bbbb89612cf621bad/roundrobin-0.0.4.tar.gz", hash = "sha256:7e9d19a5bd6123d99993fb935fa86d25c88bb2096e493885f61737ed0f5e9abd"},
 ]
+"ruff 0.0.261" = [
+    {url = "https://files.pythonhosted.org/packages/0d/92/a8ca1c04dc47e7ac2667e445654590d689105fc106026df55cbcfcac0693/ruff-0.0.261-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc970f6ece0b4950e419f0252895ee42e9e8e5689c6494d18f5dc2c6ebb7f798"},
+    {url = "https://files.pythonhosted.org/packages/14/40/96c3a8831a5fbac714ead0064ad6681526385908f2dd06f83391d6c7e08a/ruff-0.0.261-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4bcec45abdf65c1328a269cf6cc193f7ff85b777fa2865c64cf2c96b80148a2c"},
+    {url = "https://files.pythonhosted.org/packages/1b/a4/e89fbf5777404eb4b4532f5b06a709129eecdf6dcef0980688bec5f6b949/ruff-0.0.261-py3-none-win_amd64.whl", hash = "sha256:0fbc689c23609edda36169c8708bb91bab111d8f44cb4a88330541757770ab30"},
+    {url = "https://files.pythonhosted.org/packages/2e/8b/5f6b7a8d4cc8dac3dcd2573180a7dbca839a73055df2e067272c543d997f/ruff-0.0.261-py3-none-musllinux_1_2_i686.whl", hash = "sha256:39abd02342cec0c131b2ddcaace08b2eae9700cab3ca7dba64ae5fd4f4881bd0"},
+    {url = "https://files.pythonhosted.org/packages/2e/eb/8dfafe1ee789a495d85d679f5f788f275d9ea4f84add1668a05a749aadc1/ruff-0.0.261-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d1293acc64eba16a11109678dc4743df08c207ed2edbeaf38b3e10eb2597321b"},
+    {url = "https://files.pythonhosted.org/packages/41/13/3bf7e11662facd924f63944417f315d9f9dd49a0b5c96b6193d7c01f3552/ruff-0.0.261-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:581e64fa1518df495ca890a605ee65065101a86db56b6858f848bade69fc6489"},
+    {url = "https://files.pythonhosted.org/packages/42/22/15a913ffaef2be5e26c9a57beea3cb2b3d10a10022e28355ffa0178f65b3/ruff-0.0.261-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:aaa4f52a6e513f8daa450dac4859e80390d947052f592f0d8e796baab24df2fc"},
+    {url = "https://files.pythonhosted.org/packages/4f/52/530a6cff10ab024ed4d11b42ad1551961269d786787385a839ce65bbbb81/ruff-0.0.261-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f268d52a71bf410aa45c232870c17049df322a7d20e871cfe622c9fc784aab7b"},
+    {url = "https://files.pythonhosted.org/packages/63/6f/d2e08cf5b0217a8b2ba7e123c30f799c5c201a176a3bc0a74cce846ce143/ruff-0.0.261-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6c5f397ec0af42a434ad4b6f86565027406c5d0d0ebeea0d5b3f90c4bf55bc82"},
+    {url = "https://files.pythonhosted.org/packages/6b/4b/307aecf586a0747d950cb5c3e77c90c7547335aa5e57c602e80b0a9f6c20/ruff-0.0.261.tar.gz", hash = "sha256:c1c715b0d1e18f9c509d7c411ca61da3543a4aa459325b1b1e52b8301d65c6d2"},
+    {url = "https://files.pythonhosted.org/packages/6b/82/3523ff1f158883782e7df9e46575146ba202144af9cbb83a296af19e97b9/ruff-0.0.261-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d95596e2f4cafead19a6d1ec0b86f8fda45ba66fe934de3956d71146a87959b3"},
+    {url = "https://files.pythonhosted.org/packages/75/2c/3ecfee398c2608fb752caa19febab02381a4e55d7a18cae052df19cdc161/ruff-0.0.261-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:8fa98e747e0fe185d65a40b0ea13f55c492f3b5f9a032a1097e82edaddb9e52e"},
+    {url = "https://files.pythonhosted.org/packages/97/7f/141919718fcacfec51ec23e6cb5c73bddf51be58f9549830951384470eb8/ruff-0.0.261-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8dbd0cee5a81b0785dc0feeb2640c1e31abe93f0d77c5233507ac59731a626f1"},
+    {url = "https://files.pythonhosted.org/packages/9c/aa/da57cbfc20c854d339a65c082b26c4ca9b4fbc7c6496934b46c68163a3d6/ruff-0.0.261-py3-none-win_arm64.whl", hash = "sha256:d2eddc60ae75fc87f8bb8fd6e8d5339cf884cd6de81e82a50287424309c187ba"},
+    {url = "https://files.pythonhosted.org/packages/d6/a2/0d5b08e9f27d0aa5369446a6146b5b4fe4ce4625732f49858dbed8768316/ruff-0.0.261-py3-none-win32.whl", hash = "sha256:daff64b4e86e42ce69e6367d63aab9562fc213cd4db0e146859df8abc283dba0"},
+    {url = "https://files.pythonhosted.org/packages/dc/3a/209f1e016e6ed885e788b6021508aa257bd202ccbc72fae0a0f309e9e719/ruff-0.0.261-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:6624a966c4a21110cee6780333e2216522a831364896f3d98f13120936eff40a"},
+    {url = "https://files.pythonhosted.org/packages/e3/e9/717b326c9cfcf95461ea2b52a740de10da9abb0c8209a6fd29f1c946447c/ruff-0.0.261-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:2dba68a9e558ab33e6dd5d280af798a2d9d3c80c913ad9c8b8e97d7b287f1cc9"},
+]
 "setuptools 67.6.1" = [
     {url = "https://files.pythonhosted.org/packages/0b/fc/8781442def77b0aa22f63f266d4dadd486ebc0c5371d6290caf4320da4b7/setuptools-67.6.1-py3-none-any.whl", hash = "sha256:e728ca814a823bf7bf60162daf9db95b93d532948c4c0bea762ce62f60189078"},
     {url = "https://files.pythonhosted.org/packages/cb/46/22ec35f286a77e6b94adf81b4f0d59f402ed981d4251df0ba7b992299146/setuptools-67.6.1.tar.gz", hash = "sha256:257de92a9d50a60b8e22abfcbb771571fde0dbf3ec234463212027a4eeecbe9a"},
@@ -2240,9 +2211,9 @@ content_hash = "sha256:74fd6c7892917689132fa6821c6cba543d7febc92f02492356261db0a
     {url = "https://files.pythonhosted.org/packages/12/48/f9c1ec6bee313aba264fbc2483d9070f4e4526f2538e2b55b1e4a391d938/starlette-0.26.1-py3-none-any.whl", hash = "sha256:e87fce5d7cbdde34b76f0ac69013fd9d190d581d80681493016666e6f96c6d5e"},
     {url = "https://files.pythonhosted.org/packages/52/55/98746af96f57a0ff4f108c5ac84c130af3c4e291272acf446afc67d5d5d8/starlette-0.26.1.tar.gz", hash = "sha256:41da799057ea8620e4667a3e69a5b1923ebd32b1819c8fa75634bbe8d8bea9bd"},
 ]
-"starlette-admin 0.7.0" = [
-    {url = "https://files.pythonhosted.org/packages/43/c2/b1330c70ba82de4daa4182d95b5d92aeb01c193d272c2cbbfec2e23d9eff/starlette_admin-0.7.0.tar.gz", hash = "sha256:bd6a86d5635a344ccf78b078968ebd2a5ddacc7586a4c6bc321dbc2e4c7c9438"},
-    {url = "https://files.pythonhosted.org/packages/88/0e/cff418d99f62642c86c276afb24bc203206f7cddb5af003c825c36980396/starlette_admin-0.7.0-py3-none-any.whl", hash = "sha256:57c27e6d46622492f3753fe2a9100fd09b1299fd9c1782e3750ddc0e0f4b7e14"},
+"starlette-admin 0.8.0" = [
+    {url = "https://files.pythonhosted.org/packages/7c/91/1d7dedaae49a23c332c052ae14378a44d214de04a7cc17e58aba1a7d69b8/starlette_admin-0.8.0-py3-none-any.whl", hash = "sha256:d11decf08a74aeaee40570220d97a27a1eab2aa861123970f6fef90d80ad4562"},
+    {url = "https://files.pythonhosted.org/packages/e2/47/6495c05505ab22bb9f10389fe44e192b5982976ae1ebda2dfa39a81b2883/starlette_admin-0.8.0.tar.gz", hash = "sha256:8923e1ddba61e903d24307f9372a9e2e8b8827069ea0cae3c7c0b89646f9f194"},
 ]
 "termcolor 2.2.0" = [
     {url = "https://files.pythonhosted.org/packages/aa/f4/8ddd8a684b4c005345f45740a449d93d0af7ccecd91319d0f4426cf08b36/termcolor-2.2.0-py3-none-any.whl", hash = "sha256:91ddd848e7251200eac969846cbae2dacd7d71c2871e92733289e7e3666f48e7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ locust = [
 dev = [
     "uvicorn >= 0.21.0, < 1.0",
     "black >= 23.1.0, < 24.0.0",
-    "flake8 >= 6.0.0, < 7.0.0"
+    "ruff >= 0.0.261, < 0.1.0"
 ]
 docs = [
     "mkdocs >= 1.4.2",
@@ -62,3 +62,11 @@ version = { source = "file", path = "chowda/_version.py" }
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.ruff]
+ignore = [
+    # line too long
+    "E501",
+    # imported but not used
+    "F401"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,3 +70,6 @@ ignore = [
     # imported but not used
     "F401"
 ]
+[tool.ruff.per-file-ignores]
+# Ignore redifinition of config variables in db.py
+"chowda/db.py" = ["F811"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+from os import environ
+
+environ['ENVIRONMENT'] = 'test'

--- a/tests/seeds.py
+++ b/tests/seeds.py
@@ -18,7 +18,6 @@ def seed(
     num_pipelines: int = 10,
     num_clams_events: int = 800,
 ):
-
     # Create some sample CLAMS Apps and Pipelines
     clams_apps = ClamsAppFactory.create_batch(num_clams_apps)
     pipelines = PipelineFactory.create_batch(num_pipelines)

--- a/tests/seeds.py
+++ b/tests/seeds.py
@@ -1,0 +1,50 @@
+from factories import (
+    factory_session,
+    MediaFileFactory,
+    BatchFactory,
+    ClamsAppFactory,
+    PipelineFactory,
+    ClamsEventFactory,
+    CollectionFactory,
+)
+from random import sample, randint, choice
+
+
+def seed(
+    num_media_files: int = 1000,
+    num_collections: int = 100,
+    num_batches: int = 100,
+    num_clams_apps: int = 10,
+    num_pipelines: int = 10,
+    num_clams_events: int = 800,
+):
+
+    # Create some sample CLAMS Apps and Pipelines
+    clams_apps = ClamsAppFactory.create_batch(num_clams_apps)
+    pipelines = PipelineFactory.create_batch(num_pipelines)
+    for pipeline in pipelines:
+        pipeline.clams_apps = sample(clams_apps, randint(1, 4))
+
+    media_files = MediaFileFactory.create_batch(num_media_files)
+    collections = CollectionFactory.create_batch(num_collections)
+    batches = BatchFactory.create_batch(num_batches)
+
+    for batch in batches:
+        batch.pipeline = choice(pipelines)
+
+    # Randomly assign all media files to 0-3 batches and to 1 collection
+    for media_file in media_files:
+        media_file.batches = sample(batches, randint(0, 3))
+        media_file.collections = [choice(collections)]
+
+    for _ in range(num_clams_events):
+        ClamsEventFactory.create(
+            batch=choice(batches),
+            media_file=choice(batch.media_files),
+            clams_app=choice(batch.pipeline.clams_apps),
+        )
+
+    factory_session.commit()
+
+
+seed()

--- a/tests/seeds.py
+++ b/tests/seeds.py
@@ -46,4 +46,9 @@ def seed(
     factory_session.commit()
 
 
-seed()
+if __name__ == "__main__":
+    from chowda.db import engine
+    from sqlmodel import SQLModel
+
+    SQLModel.metadata.create_all(engine)
+    seed()

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -6,7 +6,7 @@ from factories import (
     PipelineFactory,
     ClamsEventFactory,
 )
-from chowda.models import MediaFile, Batch, ClamsApp
+from chowda.models import MediaFile, Batch, ClamsApp, ClamsEvent
 from chowda.db import engine
 from sqlmodel import SQLModel
 
@@ -60,8 +60,8 @@ def test_clams_event_factory():
     clams_event = ClamsEventFactory.create(
         media_file=media_file, batch=batch, clams_app=clams_app
     )
-    assert type(clams_event) is clams_event
-    assert_related(clams_event, batch=batch, media_file=media_file, clams_app=clams_app)
+    assert type(clams_event) is ClamsEvent
+    # assert_related(clams_event, batch=batch, media_file=media_file, clams_app=clams_app)
 
 
 def assert_related(model_instance: SQLModel, **kwargs):

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -61,7 +61,7 @@ def test_clams_event_factory():
         media_file=media_file, batch=batch, clams_app=clams_app
     )
     assert type(clams_event) is ClamsEvent
-    # assert_related(clams_event, batch=batch, media_file=media_file, clams_app=clams_app)
+    assert_related(clams_event, batch=batch, media_file=media_file, clams_app=clams_app)
 
 
 def assert_related(model_instance: SQLModel, **kwargs):
@@ -69,5 +69,5 @@ def assert_related(model_instance: SQLModel, **kwargs):
         if type(related) is SQLModel:
             assert related == getattr(model_instance, relation_field)
         else:
-            for related_instance in related:
+            for related_instance in list(related):
                 assert related_instance in getattr(model_instance, relation_field)


### PR DESCRIPTION
# Demo data
## Tests
### Session fixtures
- Adds engine, session fixtures from [sqlmodel docs](https://sqlmodel.tiangolo.com/tutorial/fastapi/tests/)
- Uses `sqlite://` in-memory engine
- Creates new engine for each function call

## ENVIRONMENT
Migrates `PRODUCTION` boolean to `ENVIRONMENT` string
- Default `dev`
- pytest forces `test` environment in `conftest.py`

## Seeds
- Adds `seeds.py` for database seeding example

## Models
### Batch + ClamsEvent
- Adds `pipeline` reference with `pipeline_id`
