### PR TITLE
🔆 Tweaks to display fields, seeds

### DIFF
--- a/chowda/models.py
+++ b/chowda/models.py
@@ -95,6 +95,9 @@ class Collection(SQLModel, table=True):
     async def __admin_repr__(self, request: Request):
         return f'{self.name or self.id}'
 
+    async def __admin_select2_repr__(self, request: Request):
+        return f'<span><strong>{self.name or self.id}</span>'
+
 
 class Batch(SQLModel, table=True):
     __tablename__ = 'batches'
@@ -110,6 +113,9 @@ class Batch(SQLModel, table=True):
 
     async def __admin_repr__(self, request: Request):
         return f'{self.name or self.id}'
+
+    async def __admin_select2_repr__(self, request: Request):
+        return f'<span><strong>{self.name or self.id}</span>'
 
 
 class ClamsAppPipelineLink(SQLModel, table=True):

--- a/chowda/models.py
+++ b/chowda/models.py
@@ -79,6 +79,9 @@ class MediaFile(SQLModel, table=True):
     async def __admin_repr__(self, request: Request):
         return self.guid
 
+    async def __admin_select2_repr__(self, request: Request) -> str:
+        return f'<span><strong>{self.guid}</strong></span>'
+
 
 class Collection(SQLModel, table=True):
     __tablename__ = 'collections'
@@ -146,6 +149,9 @@ class Pipeline(SQLModel, table=True):
     async def __admin_repr__(self, request: Request):
         return f'{self.name or self.id}'
 
+    async def __admin_select2_repr__(self, request: Request) -> str:
+        return f'<span><strong>{self.name or self.id}</span>'
+
 
 class ClamsEvent(SQLModel, table=True):
     __tablename__ = 'clams_events'
@@ -160,4 +166,7 @@ class ClamsEvent(SQLModel, table=True):
     media_file: Optional[MediaFile] = Relationship(back_populates='clams_events')
 
     async def __admin_repr__(self, request: Request):
-        return f'{self.batch.name}: {self.clams_app.name}: {self.status}'
+        return f'{self.clams_app.name}: {self.status}'
+
+    async def __admin_select2_repr__(self, request: Request) -> str:
+        return f'<span><strong>{self.clams_app.name}:</strong> {self.status}</span>'

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -17,7 +17,15 @@ from faker.providers import BaseProvider
 class CLAMSProvider(BaseProvider):
     '''A custom Faker provider for generating CLAMS data'''
 
-    app_names = ('Whisper', 'OCR', 'Slates', 'NER', 'Chyrons', 'Credits', 'NER')
+    app_names = (
+        'Whisper',
+        'OCR',
+        'Slates',
+        'NER',
+        'Chyrons',
+        'Credits',
+        'Bars',
+    )
 
     def app_name(self):
         return self.generator.random.choice(self.app_names)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -17,8 +17,10 @@ from faker.providers import BaseProvider
 class CLAMSProvider(BaseProvider):
     '''A custom Faker provider for generating CLAMS data'''
 
+    app_names = ('Whisper', 'OCR', 'Slates', 'NER', 'Chyrons', 'Credits', 'NER')
+
     def app_name(self):
-        return f'app-{self.generator.word(part_of_speech="noun")}'
+        return self.generator.random.choice(self.app_names)
 
     def guid(self):
         return f'cpb-aacip-{str(self.generator.random_int())}-{self.generator.hexify(8*"^")}'
@@ -113,7 +115,11 @@ class ClamsAppFactory(ChowdaFactory):
     class Meta:
         model = ClamsApp
 
-    name = factory.Faker('app_name')
+    @factory.sequence
+    def name(n):
+        index = n % len(CLAMSProvider.app_names)
+        return CLAMSProvider.app_names[index]
+
     description = factory.Faker('text')
     endpoint = factory.Faker('url')
 

--- a/tests/seeds.py
+++ b/tests/seeds.py
@@ -7,6 +7,7 @@ from factories import (
     ClamsEventFactory,
     CollectionFactory,
     UserFactory,
+    CLAMSProvider,
 )
 from chowda.models import AppStatus
 from random import sample, randint, choice
@@ -18,7 +19,7 @@ def seed(
     num_media_files: int = 1000,
     num_collections: int = 100,
     num_batches: int = 100,
-    num_clams_apps: int = 10,
+    num_clams_apps: int = len(CLAMSProvider.app_names),
     num_pipelines: int = 10,
     num_clams_events: int = 1000,
     num_users: int = 10,


### PR DESCRIPTION
* Customizes values displayed for related records.
* Use a small set of realistic ClamsApp names and only have seeds() function generate one record for each distinct app name.
* Changes ClamsEvent default display to Clams App name with Clams event status, e.g 'OCR: complete'