### PR TITLE
🥼 New lint rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,12 +82,9 @@ select = [
 
 ]
 ignore = [
-    # line too long
-    "E501",
-    # imported but not used
-    "F401",
-    # Commented out code
-    "ERA001",
-    # Missing explicit `return`
-    "RET503",
+    "E501", # line too long
+    "F401", # imported but not used
+    "ERA001", # Commented out code
+    "RET503", # Missing explicit `return`
+
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,10 +55,39 @@ version = { source = "file", path = "chowda/_version.py" }
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
+[tool.ruff.flake8-quotes]
+inline-quotes = "single"
+
 [tool.ruff]
+select = [
+    "B", # flake8-bugbear
+    "C4", # flake8-comprehensions
+    "C90", # mccabe
+    "E", # pycodestyle errors
+    "ERA", # eradicate
+    "F", # pyflakes
+    # "I", # isort
+    "INT", # flake8-gettext
+    "N", # pep8-naming
+    "PIE", # flake8-pie,
+    "PLC", # pylint - convention
+    "PLE", # pylint - error
+    "PLW", # pylint - warning
+    "Q", # flake8-quotes
+    "RET", # flake8-return,
+    "RUF", # Ruff-specific rules
+    "SIM", # flake8-simplify
+    "UP", # pyupgrade
+    "W", # pycodestyle warnings
+
+]
 ignore = [
     # line too long
     "E501",
     # imported but not used
-    "F401"
+    "F401",
+    # Commented out code
+    "ERA001",
+    # Missing explicit `return`
+    "RET503",
 ]

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -123,7 +123,7 @@ class ClamsAppFactory(ChowdaFactory):
         model = ClamsApp
 
     @factory.sequence
-    def name(n):
+    def name(n):  # noqa N805
         index = n % len(CLAMSProvider.app_names)
         return CLAMSProvider.app_names[index]
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -15,7 +15,7 @@ from faker.providers import BaseProvider
 
 
 class CLAMSProvider(BaseProvider):
-    '''A custom Faker provider for generating CLAMS data'''
+    """A custom Faker provider for generating CLAMS data"""
 
     app_names = (
         'Whisper',
@@ -36,8 +36,7 @@ class CLAMSProvider(BaseProvider):
     def collection_name(self):
         if self.generator.random.choice([True, False]):
             return self.title() + ' Collection'
-        else:
-            return self.generator.name() + ' Collection'
+        return self.generator.name() + ' Collection'
 
     def batch_name(self):
         return f'Batch {self.random_int()}: {self.title()}'

--- a/tests/seeds.py
+++ b/tests/seeds.py
@@ -19,7 +19,7 @@ def seed(
     num_media_files: int = 1000,
     num_collections: int = 100,
     num_batches: int = 100,
-    num_clams_apps: int = len(CLAMSProvider.app_names),
+    num_clams_apps: int = len(CLAMSProvider.app_names),  # noqa: B008
     num_pipelines: int = 10,
     num_clams_events: int = 1000,
     num_users: int = 10,
@@ -63,5 +63,5 @@ def seed(
     factory_session.commit()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     seed()


### PR DESCRIPTION
# Lint rules
Enhances ruff's rule set to catch more style errors. Borrowed from [starlette-admin pyproject.toml](https://github.com/jowilf/starlette-admin/blob/7f79ab37f02d73d4c2c9ad7eab3b676993e89d6d/pyproject.toml#L164-L185). 

Isort commented out for now, to be enabled when ready for production.
 
## Includes
```toml
select = [
    "B", # flake8-bugbear
    "C4", # flake8-comprehensions
    "C90", # mccabe
    "E", # pycodestyle errors
    "ERA", # eradicate
    "F", # pyflakes
    # "I", # isort
    "INT", # flake8-gettext
    "N", # pep8-naming
    "PIE", # flake8-pie,
    "PLC", # pylint - convention
    "PLE", # pylint - error
    "PLW", # pylint - warning
    "Q", # flake8-quotes
    "RET", # flake8-return,
    "RUF", # Ruff-specific rules
    "SIM", # flake8-simplify
    "UP", # pyupgrade
    "W", # pycodestyle warnings

]
```

## Single quotes
Sets inline quotes to prefer single quotes
```toml
[tool.ruff.flake8-quotes]
inline-quotes = "single"
```