### PR TITLE
❎ Removes dotenv override

### DIFF
--- a/chowda/config.py
+++ b/chowda/config.py
@@ -5,10 +5,10 @@ from dotenv import find_dotenv, load_dotenv
 CHOWDA_ENV = environ.get('CHOWDA_ENV', 'development')
 
 
-dotenv_path = find_dotenv(filename=f'.env.{CHOWDA_ENV}', raise_error_if_not_found=True)
+dotenv_path = find_dotenv(filename=f'.env.{CHOWDA_ENV}')
 
 
-load_dotenv(dotenv_path, override=True)
+load_dotenv(dotenv_path)
 
 DEBUG = bool(environ.get('DEBUG'))
 


### PR DESCRIPTION
# dotenv override
Removes `override` for dotenv config
- `ENV_VARIABLES` should override dotenv config
- Production instance should be able to set variable without creating an `.env.PRODUCTION` file