### PR TITLE
🛡 Protect sync button

### DIFF
--- a/chowda/views.py
+++ b/chowda/views.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from json import loads
 from typing import Any, ClassVar, Dict
 
@@ -16,6 +17,7 @@ from starlette_admin.exceptions import FormValidationError
 from chowda.config import API_AUDIENCE
 from chowda.db import engine
 from chowda.models import MediaFile
+from chowda.routers.dashboard import UserToken
 
 
 @dataclass
@@ -159,11 +161,18 @@ class DashboardView(CustomView):
             return []
 
     async def render(self, request: Request, templates: Jinja2Templates) -> Response:
+        history = self.sync_history()
+        user = UserToken(**request.state.user)
+        sync_disabled = (
+            datetime.now() - history[0]['created_at'] < timedelta(minutes=15),
+        )
         return templates.TemplateResponse(
             'dashboard.html',
             {
                 'request': request,
-                'sync_history': self.sync_history(),
+                'user': user,
+                'sync_history': history,
+                'sync_disabled': sync_disabled,
                 'flash': request.session.pop('flash', ''),
                 'error': request.session.pop('error', ''),
             },

--- a/chowda/views.py
+++ b/chowda/views.py
@@ -163,8 +163,8 @@ class DashboardView(CustomView):
     async def render(self, request: Request, templates: Jinja2Templates) -> Response:
         history = self.sync_history()
         user = UserToken(**request.state.user)
-        sync_disabled = (
-            datetime.now() - history[0]['created_at'] < timedelta(minutes=15),
+        sync_disabled = datetime.now() - history[0]['created_at'] < timedelta(
+            minutes=15
         )
         return templates.TemplateResponse(
             'dashboard.html',

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -61,15 +61,17 @@
                         </div>
                     </div>
             </div>
+            {% if 'admin' in user.roles %}
             <div class="card-footer text-black">
                 <div class="btn-list ms-auto justify-content-end">
-                    <button type="submit" name="_add_another" class="btn">
+                    <button type="submit" name="_add_another" class="btn" {{ 'disabled' if sync_disabled }}>
                         <i class="fa-solid fa-rotate me-2">
                         </i>
                         {{ _("Sync Now")}}
                     </button>
                 </div>
             </div>
+            {% endif %}
             </form>
         </div>
     </div>


### PR DESCRIPTION
# Sync button
- Sync button only appears to admins
  - Closes #105
- Protects sync button from multiple presses
  - 15 minutes from latest run
  - Does not prevent race conditions from multiple presses on different pages
  - Does not update other pages that have not refreshed
  - Closes #104 
