### PR TITLE
Fixes html tag mistmatch in dashbaord template

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -60,28 +60,26 @@
                             {% endif %}
                         </div>
                     </div>
+                    {% if 'admin' in user.roles %}
+                    <div class="card-footer text-black">
+                        <div class="btn-list ms-auto justify-content-end">
+                            <button type="submit" name="_add_another" class="btn" {{ 'disabled' if sync_disabled }}>
+                                <i class="fa-solid fa-rotate me-2">
+                                </i>
+                                {{ _("Sync Now")}}
+                            </button>
+                        </div>
+                    </div>
+                    {% endif %}
+                </form>
             </div>
-            {% if 'admin' in user.roles %}
-            <div class="card-footer text-black">
-                <div class="btn-list ms-auto justify-content-end">
-                    <button type="submit" name="_add_another" class="btn" {{ 'disabled' if sync_disabled }}>
-                        <i class="fa-solid fa-rotate me-2">
-                        </i>
-                        {{ _("Sync Now")}}
-                    </button>
-                </div>
-            </div>
-            {% endif %}
-            </form>
         </div>
     </div>
-</div>
 </div>
 {% endblock %}
 {% block head_css %}
 {{ super() }}
 {% endblock %}
 {% block script %}
-new DataTable('#sync_history');
 {{ super() }}
 {% endblock %}


### PR DESCRIPTION
For some reason there seemed to be an errant closing </div> tag. It was not having an effect on display.

Also removed DataTables from #sync_history, as there was no element with id="sync_history", and when i tried adding it, it errored with "DataTables is not defined" anyway.

The table of sync history looks fine right now, so scrapping it.