### PR TITLE
📰 publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: 🏛 Publish to PyPi
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: 📦 Build package
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📰 Checkout
+        uses: actions/checkout@v3
+
+      - name: 📲 Setup PDM
+        uses: pdm-project/setup-pdm@v3
+        id: setup-python
+        with:
+          python-version: 3.x
+
+      - name: 🚚 Install dependencies
+        run: pdm install --prod
+
+      - name: 🏗️ Build package
+        run: pdm build
+
+      - name: 🛫 Export build files
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist
+
+  publish:
+    name: 🗞 Publish package
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: 🛬 Download artifacts
+        uses: actions/download-artifact@v3
+
+      - name: 🗞 Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
# Publish
Adds publish workflow
- Copied from [sonyci](https://github.com/WGBH-MLA/sonyci/blob/main/.github/workflows/publish.yml) because our [reusable workflow](https://github.com/WGBH-MLA/.github/blob/main/.github/workflows/publish.yml) should work, but doesn't because [PyPi trusted publishing requires reusable workflows to be in the same repository as the workflow that calls them.](https://github.com/pypi/warehouse/issues/11096)
