### PR TITLE
🛡 GitGuardian

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,27 @@ sequenceDiagram
     deactivate User
 
 ```
+
+## develop
+
+### pre-commit secret scanning
+
+0. Install [ggshield](https://docs.gitguardian.com/ggshield-docs/getting-started)
+
+```shell
+pip install ggshield
+# or
+brew install gitguardian/tap/ggshield
+```
+
+1. Login to gitguardian
+
+```shell
+ggshield auth login
+```
+
+2. Install the pre-commit hooks
+
+```shell
+pre-commit install
+```

--- a/pre-commit-config.yml
+++ b/pre-commit-config.yml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/gitguardian/ggshield
+    rev: v1.18.1
+    hooks:
+      - id: ggshield
+        language_version: python3
+        stages: [commit]


### PR DESCRIPTION
# GitGuardian
Adds gitguardian pre-commit hook

## Usage
0. Install [ggshield](https://docs.gitguardian.com/ggshield-docs/getting-started)

```shell
pip install ggshield
# or
brew install gitguardian/tap/ggshield
```

1. Login to gitguardian

```shell
ggshield auth login
```

2. Install the pre-commit hooks

```shell
pre-commit install
```
