### PR TITLE
📙 `page_size_options`

### DIFF
--- a/chowda/fields.py
+++ b/chowda/fields.py
@@ -51,12 +51,12 @@ class SonyCiAssetThumbnail(BaseField):
     label: str = 'Thumbnail'
     display_template: str = 'displays/sony_ci_asset_thumbnail.html'
     read_only: bool = True
-    exclude_from_create: bool = True
+    exclude_from_edit: bool = True
 
     render_function_key: str = 'sony_ci_asset_thumbnail'
 
     async def parse_obj(self, request: Request, obj: Any) -> Any:
-        return obj.thumbnails_by_type.get('standard')
+        return obj.thumbnails_by_type.get('small')
 
 
 @dataclass

--- a/chowda/views.py
+++ b/chowda/views.py
@@ -30,10 +30,14 @@ from chowda.models import Batch, Collection, MediaFile
 from chowda.utils import validate_media_file_guids
 
 
-class BaseModelView(ModelView):
+class ChowdaModelView(ModelView):
     """Base permissions for all views"""
 
     page_size_options: ClassVar[list[int]] = [10, 25, 100, 500, 2000, 10000]
+
+
+class ClammerModelView(ChowdaModelView):
+    """Base Clammer permissions for all protected views"""
 
     def can_create(self, request: Request) -> bool:
         return get_user(request).is_clammer
@@ -45,7 +49,7 @@ class BaseModelView(ModelView):
         return get_user(request).is_clammer
 
 
-class AdminModelView(BaseModelView):
+class AdminModelView(ClammerModelView):
     """Base Admin permissions for all protected views"""
 
     def is_accessible(self, request: Request) -> bool:
@@ -62,7 +66,7 @@ class AdminModelView(BaseModelView):
         return get_user(request).is_admin
 
 
-class CollectionView(BaseModelView):
+class CollectionView(ClammerModelView):
     exclude_fields_from_list: ClassVar[list[Any]] = [Collection.media_files]
     exclude_fields_from_detail: ClassVar[list[Any]] = [Collection.id]
 
@@ -154,7 +158,7 @@ class CollectionView(BaseModelView):
         return f'Created Batches from {", ".join(names)}'
 
 
-class BatchView(BaseModelView):
+class BatchView(ClammerModelView):
     exclude_fields_from_create: ClassVar[list[Any]] = [Batch.id]
     exclude_fields_from_edit: ClassVar[list[Any]] = [Batch.id]
     exclude_fields_from_list: ClassVar[list[Any]] = [Batch.media_files]
@@ -285,7 +289,7 @@ class BatchView(BaseModelView):
         return f'Combined {len(pks)} Batch(es)'
 
 
-class MediaFileView(BaseModelView):
+class MediaFileView(ClammerModelView):
     pk_attr: str = 'guid'
     actions: ClassVar[List[str]] = ['create_new_batch']
 
@@ -339,7 +343,7 @@ class UserView(AdminModelView):
     fields: ClassVar[list[Any]] = ['first_name', 'last_name', 'email']
 
 
-class ClamsAppView(BaseModelView):
+class ClamsAppView(ClammerModelView):
     fields: ClassVar[list[Any]] = ['name', 'endpoint', 'description', 'pipelines']
 
 

--- a/chowda/views.py
+++ b/chowda/views.py
@@ -33,7 +33,7 @@ from chowda.utils import validate_media_file_guids
 class ChowdaModelView(ModelView):
     """Base permissions for all views"""
 
-    page_size_options: ClassVar[list[int]] = [10, 25, 100, 500, 2000, 10000]
+    page_size_options: ClassVar[list[int]] = [10, 25, 100, 1000, -1]
 
 
 class ClammerModelView(ChowdaModelView):
@@ -291,6 +291,7 @@ class BatchView(ClammerModelView):
 
 class MediaFileView(ClammerModelView):
     pk_attr: str = 'guid'
+
     actions: ClassVar[List[str]] = ['create_new_batch']
 
     fields: ClassVar[list[str]] = [
@@ -301,6 +302,7 @@ class MediaFileView(ClammerModelView):
         'mmif_json',
     ]
     exclude_fields_from_list: ClassVar[list[str]] = ['mmif_json']
+    page_size_options: ClassVar[list[int]] = [10, 25, 100, 500, 2000, 10000]
 
     def can_create(self, request: Request) -> bool:
         return get_user(request).is_admin
@@ -392,6 +394,8 @@ class SonyCiAssetView(AdminModelView):
         'format',
         'media_files',
     ]
+
+    page_size_options: ClassVar[list[int]] = [10, 25, 100, 500, 2000, 10000]
 
     def can_create(self, request: Request) -> bool:
         """Sony Ci Assets are ingested from Sony Ci API, not created from the UI."""

--- a/chowda/views.py
+++ b/chowda/views.py
@@ -33,6 +33,8 @@ from chowda.utils import validate_media_file_guids
 class BaseModelView(ModelView):
     """Base permissions for all views"""
 
+    page_size_options: ClassVar[list[int]] = [10, 25, 100, 500, 2000, -1]
+
     def can_create(self, request: Request) -> bool:
         return get_user(request).is_clammer
 
@@ -43,7 +45,7 @@ class BaseModelView(ModelView):
         return get_user(request).is_clammer
 
 
-class AdminModelView(ModelView):
+class AdminModelView(BaseModelView):
     """Base Admin permissions for all protected views"""
 
     def is_accessible(self, request: Request) -> bool:

--- a/chowda/views.py
+++ b/chowda/views.py
@@ -33,7 +33,7 @@ from chowda.utils import validate_media_file_guids
 class BaseModelView(ModelView):
     """Base permissions for all views"""
 
-    page_size_options: ClassVar[list[int]] = [10, 25, 100, 500, 2000, -1]
+    page_size_options: ClassVar[list[int]] = [10, 25, 100, 500, 2000, 10000]
 
     def can_create(self, request: Request) -> bool:
         return get_user(request).is_clammer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,9 +68,6 @@ omit = ['tests/*']
 [tool.pytest.ini_options]
 testpaths = ['tests', 'docs']
 
-[tool.ruff.flake8-quotes]
-inline-quotes = 'single'
-
 [tool.ruff]
 extend-exclude = ['migrations']
 ignore = ['Q000']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ omit = ['tests/*']
 [tool.pytest.ini_options]
 testpaths = ['tests', 'docs']
 
+[tool.ruff.flake8-quotes]
+inline-quotes = 'single'
+
 [tool.ruff]
 extend-exclude = ['migrations']
 ignore = ['Q000']

--- a/static/js/custom_render.js
+++ b/static/js/custom_render.js
@@ -2,7 +2,7 @@ Object.assign(render, {
   media_file_guid_links: function render(data, type, full, meta, fieldOptions) {
     // Render a list of media files to a string of links to media files
     return data.map(
-      (guid) => `<a href="../media-file/detail/${guid}"> ${guid} </a>`
+      guid => `<a href="../media-file/detail/${guid}"> ${guid} </a>`
     )
   },
   media_file_count: function render(data, type, full, meta, fieldOptions) {
@@ -18,7 +18,7 @@ Object.assign(render, {
     fieldOptions
   ) {
     return data
-      ? `<img src="${data.location}" style="max-height:150px;">`
+      ? `<img src="${data.location}" style="max-height:150px;" loading="lazy">`
       : null
   },
 })


### PR DESCRIPTION
# `page_size_options`
Adds default page sizes for all model views: `[10, 25, 100, 1000, -1]` where `-1` is "All"

## `MediaFile` and `SonyCiAsset` Views
Limits to 10k for performance reasons (see 👇): `[10, 25, 100, 500, 2000, 10000]`

## ~~View All Assets~~
It is technically possible to show "All" SonyCiAssets with `-1`, but queries that large (180k rows) broke the server.
  - Including when pod was allowed extra resources, and allowed 2 minutes to respond.

Rows displayed after the first few thousand make the page basically unresponsive, so capped at `10k`

With 10k rows:
- Server request time: ~ 5s
- Request download time: ~ 20s (10MB)
- Page load time: ~ 20s after download.

Closes #146 

## Misc
- Changes `BaseModelView` -> `ChowdaModelView`
- Uses `small` thumbnails for list view
- Lazy load thumbnails