### PR TITLE
🏚 Fixes `MediaFilesGuidsField`

### DIFF
--- a/chowda/fields.py
+++ b/chowda/fields.py
@@ -11,10 +11,17 @@ from chowda.models import MediaFile
 
 @dataclass
 class MediaFilesGuidsField(TextAreaField):
-    """A field that displays a list of MediaFile GUIDs as html links"""
+    """A field that displays a list of MediaFile GUIDs
+    Edit view: Textarea with GUIDs as strings
+    List view: Comma separated list of GUID Links
+    Detail view: Datatable with GUID links
+    """
 
-    render_function_key: str = 'media_file_guid_links'
+    id = 'media_file_guids'
+    label: str = 'Media Files'
+    display_template: str = 'displays/collection_media_files.html'
     form_template: str = 'forms/media_file_guids_textarea.html'
+    render_function_key: str = 'media_file_guid_links'
 
     async def parse_form_data(
         self, request: Request, form_data: FormData, action: RequestAction
@@ -26,7 +33,9 @@ class MediaFilesGuidsField(TextAreaField):
         self, request: Request, value: Any, action: RequestAction
     ) -> Any:
         """Maps a Collection's MediaFile objects to a list of GUIDs"""
-        return [media_file.guid for media_file in value]
+        if request.state.action in (RequestAction.EDIT, RequestAction.LIST):
+            return [media_file.guid for media_file in value]
+        return value
 
 
 @dataclass
@@ -127,7 +136,7 @@ class BatchPercentSuccessful(BaseField):
 class BatchUnstartedGuids(BaseField):
     """GUIDs in a batch that have not yet started"""
 
-    name: str = 'batch_unstarted_guids'
+    id: str = 'batch_unstarted_guids'
     read_only: bool = True
     label: str = 'Unstarted GUIDs'
     exclude_from_create: bool = True

--- a/chowda/views.py
+++ b/chowda/views.py
@@ -102,20 +102,7 @@ class CollectionView(ClammerModelView):
         'description',
         MediaFileCount(),
         # 'media_files',  # default view
-        MediaFilesGuidsField(
-            'media_files',
-            id='media_file_guids',
-            label='GUIDs',
-            exclude_from_detail=True,
-        ),
-        BaseField(
-            'media_files',
-            display_template='displays/collection_media_files.html',
-            label='Media Files',
-            exclude_from_edit=True,
-            exclude_from_create=True,
-            exclude_from_list=True,
-        ),
+        MediaFilesGuidsField('media_files', label='GUIDs'),
     ]
 
     async def validate(self, request: Request, data: Dict[str, Any]):
@@ -208,13 +195,8 @@ class BatchView(ClammerModelView):
         BatchPercentCompleted(),
         BatchPercentSuccessful(),
         BatchUnstartedGuidsCount(),
-        BatchUnstartedGuids(),
-        MediaFilesGuidsField(
-            'media_files',
-            id='media_file_guids',
-            label='GUIDs',
-            exclude_from_detail=True,
-        ),
+        BatchUnstartedGuids('media_files'),
+        MediaFilesGuidsField('media_files', exclude_from_detail=True),
         BatchMetaflowRunDisplayField(),
     ]
 


### PR DESCRIPTION
# `MediaFilesGuidsField`
Fixes `MediaFilesGuidsField` so `Batches` and `Collections` Relationships shows up on `MediaFiles` edit page.

Closes #169 