### PR TITLE
⌛ Expires all

### DIFF
--- a/chowda/app.py
+++ b/chowda/app.py
@@ -70,7 +70,7 @@ admin = Admin(
 admin.add_view(MediaFileView(MediaFile, icon='fa fa-file-video'))
 admin.add_view(SonyCiAssetView(SonyCiAsset, icon='fa fa-file-video'))
 admin.add_view(CollectionView(Collection, icon='fa fa-folder'))
-admin.add_view(BatchView(Batch, icon='fa fa-folder', label='Batches'))
+admin.add_view(BatchView(Batch, icon='fa fa-folder'))
 admin.add_view(ClamsAppView(ClamsApp, icon='fa fa-box'))
 admin.add_view(PipelineView(Pipeline, icon='fa fa-boxes-stacked'))
 admin.add_view(UserView(User, icon='fa fa-users'))

--- a/chowda/fields.py
+++ b/chowda/fields.py
@@ -111,7 +111,7 @@ class BatchPercentCompleted(BaseField):
 
     async def parse_obj(self, request: Request, obj: Any) -> Any:
         runs = [run.finished for run in obj.metaflow_runs]
-        if runs:
+        if runs and obj.media_files:
             return f'{runs.count(True) / len(obj.media_files):.1%}'
         return None
 
@@ -127,7 +127,7 @@ class BatchPercentSuccessful(BaseField):
 
     async def parse_obj(self, request: Request, obj: Any) -> Any:
         runs = [run.successful for run in obj.metaflow_runs]
-        if runs:
+        if runs and obj.media_files:
             return f'{runs.count(True) / len(obj.media_files):.1%}'
         return None
 

--- a/chowda/models.py
+++ b/chowda/models.py
@@ -148,7 +148,7 @@ class SonyCiAssetThumbnail(SQLModel):
 
 class SonyCiAsset(SQLModel, table=True):
     __tablename__ = 'sonyci_assets'
-    id: str = Field(primary_key=True, index=True)
+    id: Optional[str] = Field(primary_key=True, index=True, default=None)
     name: str = Field(index=True)
     size: int = Field(index=True, sa_column=Column(postgresql.BIGINT))
     type: MediaType = Field(sa_column=Column(Enum(MediaType)))

--- a/chowda/utils.py
+++ b/chowda/utils.py
@@ -2,7 +2,6 @@ from typing import Any, Dict
 
 from pydantic import BaseModel
 from sqlalchemy.dialects.postgresql import insert
-
 from starlette.requests import Request
 
 
@@ -57,11 +56,15 @@ def validate_media_file_guids(request: Request, data: Dict[str, Any]):
     relate to Batch and  Collection objects.
     """
     from sqlmodel import Session, select
-    from chowda.db import engine
-    from chowda.models import MediaFile
     from starlette_admin.exceptions import FormValidationError
 
+    from chowda.db import engine
+    from chowda.models import MediaFile
+
     media_files = []
+
+    # Clear the session to avoid conflicts with session instances used by the API
+    request.state.session.expire_all()
 
     with Session(engine) as db:
         # Get all MediaFiles objects for the GUIDs in data['media_files']

--- a/chowda/views.py
+++ b/chowda/views.py
@@ -172,6 +172,7 @@ class CollectionView(ClammerModelView):
 
 
 class BatchView(ClammerModelView):
+    label: ClassVar[str] = 'Batches'
     exclude_fields_from_create: ClassVar[list[Any]] = [Batch.id]
     exclude_fields_from_edit: ClassVar[list[Any]] = [Batch.id]
     exclude_fields_from_list: ClassVar[list[Any]] = [Batch.media_files]


### PR DESCRIPTION
# GUID validation
Fixes guid validation with `session.expire_all()`

Closes #114 ... again...

## Misc
- Changes `SonyCiAsset.id` to `Optional` to fix validation
- Protects percent complete fields from zero division
